### PR TITLE
Issue 22 - Prevention of overlapping booking dates

### DIFF
--- a/app/controllers/booking_controller.rb
+++ b/app/controllers/booking_controller.rb
@@ -53,6 +53,7 @@ class BookingController < ApplicationController
             flash[:notification] = "Booking #{booking.id} sucessfully updated"
         else
             flash[:alert] = "No changes made."
+            booking.errors.each { | attribute, error_message | flash[:alert] += " #{error_message}" } unless booking.nil?
             flash[:alert] += " Invalid arrival date given." if error_attributes.include? :arrival_date
             flash[:alert] += " Invalid departure date given." if error_attributes.include? :departure_date            
         end
@@ -72,6 +73,9 @@ class BookingController < ApplicationController
             flash[:notification] = "New Booking succesfully created"
         else
             flash[:alert] = "Booking not created."
+            @booking.errors.each do | attribute, error_message |
+                flash[:alert] += " #{error_message}"
+            end
             flash[:alert] += " Invalid arrival date given." if error_attributes.include? :arrival_date
             flash[:alert] += " Invalid departure date given." if error_attributes.include? :departure_date            
         end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,8 +1,24 @@
 class Booking < ApplicationRecord
+    validate :unique_dates
+    
     #Get the bookings with date attributes between the date range for the arrival and departure dates
     def self.bookings_within(date_range)
         arrivals   = Booking.where(:arrival_date => date_range)
         departures = Booking.where(:departure_date => date_range)
         (arrivals + departures).uniq
+    end
+    
+    private
+    
+    def unique_dates
+        begin
+            date_range = (self.arrival_date.tomorrow)..(self.departure_date.yesterday)
+            overlapping=Booking.bookings_within(date_range)
+            if overlapping.length > 0
+                errors.add(:overlapping_dates, "Overlapping arrival/departure dates given.")                
+            end
+        rescue
+            errors.add(:dates, "Invalid date given.")  
+        end
     end
 end

--- a/features/booking_edit_create.feature
+++ b/features/booking_edit_create.feature
@@ -6,7 +6,7 @@ Feature: Edit and Create bookings
   Background:
     Given the following bookings exist:
       | id  | name   | postcode | country   | contact_number   | email_address   | number_of_people | estimated_arrival_time | preferred_payment_method | arrival_date | departure_date | cost | status   |
-      | 12   | test_1 | 5000     | Australia | +61234567890     | test@domain.com | 4                | 3pm                    | cash                     | 20-1-2018    | 25-1-2018      | 123  | booked   |
+      | 12  | test_1 | 5000     | Australia | +61234567890     | test@domain.com | 4                | 3pm                    | cash                     | 20-1-2018    | 25-1-2018      | 123  | booked   |
       | 14  | test_2 |          | Indonesia | +62 21 6539-0605 | test@foreign.id | 5                | 2pm                    | direct_debit             | 25-1-2018    | 2-2-2018       | 1000 | reserved |
       | 23  | test_3 |          | Austria   | 0043-1-893 42 02 | test@foreign.at | 1                | 9pm                    | cash                     | 15-5-2017    | 25-5-2017      | 800  | booked   | 
       | 34  | test_4 | 2158     | Australia | +61098765432     | test@dom.com.au | 2                | 4pm                    | cash                     | 29-5-2018    | 3-6-2018       | 132  | reserved |
@@ -81,6 +81,46 @@ Feature: Edit and Create bookings
       | junk_date              |
     And I press "Save"
     Then I should see "No changes made. Invalid departure date given."
+    
+  @javascript
+  Scenario: Overlapping booking dates on edit
+    Given I am on the administration booking manager page
+    And I click on the "Booking" for the dates "20-1-2018" to "25-1-2018"    
+    And I enter the following values into the corresponding fields:
+      | booking_departure_date |
+      | 26-1-2018              |
+    And I press "Save"
+    Then I should see "No changes made. Invalid departure date given."
+    
+  @javascript
+  Scenario: Overlapping booking dates on creation
+    Given I am on the administration booking manager page  
+    And I press "Add"
+    And I enter the following values into the corresponding fields:
+      | booking_name | booking_arrival_date | booking_departure_date |
+      | test_7       | 2018-02-01           | 2018-02-04             |
+    And I press "Save"
+    Then I should see "No changes made. Invalid arrival date given."
+    
+  @javascript
+  Scenario: Valid same arrival dates for existing booking departure
+    Given I am on the administration booking manager page
+    And I click on the "Booking" for the dates "5-3-2018" to "10-3-2018"    
+    And I enter the following values into the corresponding fields:
+      | booking_arrival_date |
+      | 2-2-2018             |
+    And I press "Save"
+    Then I should see "Booking 56 sucessfully updated"    
+  
+  @javascript
+  Scenario: Valid same departure dates for existing booking arrival
+    Given I am on the administration booking manager page  
+    And I press "Add"
+    And I enter the following values into the corresponding fields:
+      | booking_name | booking_arrival_date | booking_departure_date |
+      | test_7       | 2018-05-27           | 2018-05-29             |
+    And I press "Save"
+    Then I should see "New Booking succesfully created"    
     
   @javascript
   Scenario: Invalid arrival date entered on new booking

--- a/features/booking_edit_create.feature
+++ b/features/booking_edit_create.feature
@@ -91,7 +91,7 @@ Feature: Edit and Create bookings
       | booking_departure_date |
       | 26-1-2018              |
     And I press "Save"
-    Then I should see "Invalid or overlapping arrival/departure dates given."
+    Then I should see "No changes made. Overlapping arrival/departure dates given."
     
   @javascript
   Scenario: Overlapping booking dates on creation
@@ -101,7 +101,7 @@ Feature: Edit and Create bookings
       | booking_name | booking_arrival_date | booking_departure_date |
       | test_7       | 2018-02-01           | 2018-02-04             |
     And I press "Save"
-    Then I should see "Invalid or overlapping arrival/departure dates given."
+    Then I should see "Booking not created. Overlapping arrival/departure dates given."
     
   @javascript
   Scenario: Valid same arrival dates for existing booking departure

--- a/features/booking_edit_create.feature
+++ b/features/booking_edit_create.feature
@@ -85,12 +85,13 @@ Feature: Edit and Create bookings
   @javascript
   Scenario: Overlapping booking dates on edit
     Given I am on the administration booking manager page
-    And I click on the "Booking" for the dates "20-1-2018" to "25-1-2018"    
+    And I click on the "Booking" for the dates "20-1-2018" to "25-1-2018"
+    And I press "Edit"
     And I enter the following values into the corresponding fields:
       | booking_departure_date |
       | 26-1-2018              |
     And I press "Save"
-    Then I should see "No changes made. Invalid departure date given."
+    Then I should see "Invalid or overlapping arrival/departure dates given."
     
   @javascript
   Scenario: Overlapping booking dates on creation
@@ -100,17 +101,20 @@ Feature: Edit and Create bookings
       | booking_name | booking_arrival_date | booking_departure_date |
       | test_7       | 2018-02-01           | 2018-02-04             |
     And I press "Save"
-    Then I should see "No changes made. Invalid arrival date given."
+    Then I should see "Invalid or overlapping arrival/departure dates given."
     
   @javascript
   Scenario: Valid same arrival dates for existing booking departure
     Given I am on the administration booking manager page
-    And I click on the "Booking" for the dates "5-3-2018" to "10-3-2018"    
+    And I click on the "Booking" for the dates "20-1-2018" to "25-1-2018" 
+    And I press "Edit" 
     And I enter the following values into the corresponding fields:
-      | booking_arrival_date |
-      | 2-2-2018             |
+      | booking_arrival_date | booking_departure_date |
+      | 2018-01-19           | 2018-01-25             |    
     And I press "Save"
-    Then I should see "Booking 56 sucessfully updated"    
+    And I click on the "Booking" for the dates "19-1-2018" to "25-1-2018"
+    Then I should see "2018-01-19"
+    And I should see "2018-01-25"
   
   @javascript
   Scenario: Valid same departure dates for existing booking arrival

--- a/spec/controllers/booking_controller_spec.rb
+++ b/spec/controllers/booking_controller_spec.rb
@@ -284,6 +284,15 @@ RSpec.describe BookingController, type: :controller do
                     expect(flash[:alert]).to eq("No changes made. Invalid departure date given.")
                     expect(response).to redirect_to(administration_booking_manager_path)                
                 end
+
+                it "sets flash[:alert] and redirects when the given dates overlap with existing dates" do
+                    @booking_2 = FactoryBot.create(:booking, name: "test_1", 
+                        arrival_date: "25-01-2018", departure_date: "27-01-2018")
+                    new_values = {arrival_date: "20-1-2018", departure_date: "26-01-2018"}
+                    put :update, params: {id: @booking_1.id, booking: new_values}
+                    expect(flash[:alert]).to eq("No changes made. Overlapping arrival/departure dates given.")
+                end
+                
             end
         end
     end
@@ -412,7 +421,6 @@ RSpec.describe BookingController, type: :controller do
                     new_values = {name: "test_7", arrival_date: "21-1-2018", departure_date: "24-1-2018", status: "reserved"}
                     post :create, params: {booking: new_values}
                     expect(flash[:notification]).to eq("New Booking succesfully created")
-                    expect(response).to redirect_to(administration_booking_manager_path)
                 end
             end
             
@@ -439,6 +447,14 @@ RSpec.describe BookingController, type: :controller do
                     new_values = {name: "test_7", arrival_date: "26-1-2018", departure_date: "24-1-2018", status: "reserved"}  
                     post :create, params: {booking: new_values}
                     expect(flash[:alert]).to eq("Booking not created. Invalid departure date given.")            
+                end
+                
+                it "sets flash[:alert] and redirects when the given dates overlap with existing dates" do
+                    @booking_1 = FactoryBot.create(:booking, name: "test_1", 
+                        arrival_date: "20-1-2018", departure_date: "25-1-2018")
+                    new_values = {name: "test_7", arrival_date: "24-1-2018", departure_date: "26-1-2018", status: "reserved"}
+                    post :create, params: {booking: new_values}
+                    expect(flash[:alert]).to eq("Booking not created. Overlapping arrival/departure dates given.")
                 end
             end
         end

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Booking, type: :model do
   describe "bookings_within" do
     before :each do 
       @booking_1 = FactoryBot.create(:booking, name: "test_1", arrival_date: "20-1-2018", departure_date: "25-1-2018")
-      @booking_2 = FactoryBot.create(:booking, name: "test_2", arrival_date: "31-1-2017", departure_date: "5-1-2018")
+      @booking_2 = FactoryBot.create(:booking, name: "test_2", arrival_date: "31-1-2018", departure_date: "5-1-2018")
       @booking_3 = FactoryBot.create(:booking, name: "test_3", arrival_date: "15-5-2017", departure_date: "25-5-2017")
       @booking_4 = FactoryBot.create(:booking, name: "test_4", arrival_date: "29-5-2018", departure_date: "3-6-2018")
       @booking_5 = FactoryBot.create(:booking, name: "test_5", arrival_date: "1-8-2019",  departure_date: "2-10-2019")
@@ -22,6 +22,40 @@ RSpec.describe Booking, type: :model do
       expect(test_result.include? @booking_3).to eq(false)
       expect(test_result.include? @booking_5).to eq(false)
       expect(test_result.length).to eq(4)
+    end
+  end
+  
+  describe "validation" do
+    before :each do
+      @booking_1 = FactoryBot.create(:booking, name: "test_1", arrival_date: "20-1-2018", departure_date: "25-1-2018")
+      @booking_2 = FactoryBot.create(:booking, name: "test_2", arrival_date: "31-1-2018", departure_date: "5-1-2018")      
+    end
+    
+    it "allows for bookings with the same departure date and arrival dates of other bookings to be stored" do
+      booking = Booking.new(name: "test_3", arrival_date: "25-1-2018", departure_date: "31-1-2018")
+      expect(booking.save).to eq(true)
+    end
+    
+    describe "overlapping dates" do
+      it "forces save to evaluate to false with overlapping dates" do
+        booking = Booking.new(name: "test_3", arrival_date: "25-1-2018", departure_date: "1-2-2018")
+        expect(booking.save).to eq(false)
+      end
+      
+      it "adds invalid date messages to the error of the booking" do
+        booking = Booking.new(name: "test_3", arrival_date: "25-1-2018", departure_date: "1-2-2018")
+        booking.save
+        expect(booking.errors[:overlapping_dates]).to eq(["Overlapping arrival/departure dates given."])
+      end
+      
+      it "does not save the booking" do
+        booking = Booking.new(name: "test_3", arrival_date: "25-1-2018", departure_date: "1-2-2018")
+        booking.save
+        expect(Booking.all.include? @booking_1).to eq(true)
+        expect(Booking.all.include? @booking_2).to eq(true)
+        expect(Booking.all.include? booking).to eq(false)        
+        expect(Booking.all.length).to eq(2)
+      end
     end
   end
   


### PR DESCRIPTION
This merge will prevent users from adding bookings which overlap with other booking dates, as a part of issue #22. 