### PR TITLE
Correct the Subject line of the Reservation response email

### DIFF
--- a/app/mailers/booking_mailer.rb
+++ b/app/mailers/booking_mailer.rb
@@ -2,7 +2,7 @@ class BookingMailer < ApplicationMailer
     
     def booking_confirmation_email(booking)
         @booking = booking
-        mail to: booking.email_address, subject: "Carob Cottage: Reservation Confirmation"
+        mail to: booking.email_address, subject: "Carob Cottage: Reservation Request"
     end
     
     def booking_admin_email(admin, booking)


### PR DESCRIPTION
The automated response email generated when a user places a reservation request no longer has a subject that implies a guaranteed booking. 

Resolves: #68 
